### PR TITLE
Option-local custom argument help

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ option(CXXOPTS_BUILD_TESTS "Set to ON to build tests" ${CXXOPTS_STANDALONE_PROJE
 option(CXXOPTS_ENABLE_INSTALL "Generate the install target" ${CXXOPTS_STANDALONE_PROJECT})
 option(CXXOPTS_ENABLE_WARNINGS "Add warnings to CMAKE_CXX_FLAGS" ${CXXOPTS_STANDALONE_PROJECT})
 option(CXXOPTS_USE_UNICODE_HELP "Use ICU Unicode library" OFF)
+option(CXXOPTS_ENABLE_ARG_FORMAT "Allow custom formats for implicit values" OFF)
 
 if (CXXOPTS_STANDALONE_PROJECT)
     cxxopts_set_cxx_standard()
@@ -80,4 +81,9 @@ endif()
 if (CXXOPTS_BUILD_TESTS)
     enable_testing()
     add_subdirectory(test)
+endif()
+
+if (CXXOPTS_ENABLE_ARG_FORMAT)
+    target_compile_features(cxxopts INTERFACE cxx_std_20)
+    target_compile_definitions(cxxopts INTERFACE CXXOPTS_ENABLE_ARG_FORMAT)
 endif()

--- a/src/example.cpp
+++ b/src/example.cpp
@@ -52,6 +52,12 @@ parse(int argc, const char* argv[])
       ("i,input", "Input", cxxopts::value<std::string>())
       ("o,output", "Output file", cxxopts::value<std::string>()
           ->default_value("a.out")->implicit_value("b.def"), "BIN")
+#if __cplusplus >= 202002L
+      ("formatted_option", "Option with implicit value and custom format", cxxopts::value<std::string>()->implicit_value("abcd")->arg_format("[{}]={}"), "arg_help")
+      ("formatted_option2", "Another option with implicit value and custom format", cxxopts::value<std::string>()->implicit_value("abcd")->arg_format("[{}={}]"), "arg_help")
+      ("formatted_option3", "One more option with implicit value and custom format", cxxopts::value<std::string>()->implicit_value("abcd")->arg_format("[{} = {}]"), "arg_help")
+      ("no_implicit", "Same as formatted_option but no implicit value", cxxopts::value<std::string>()->arg_format("[{}]={}"), "arg_help")
+#endif
       ("x", "A short-only option", cxxopts::value<std::string>())
       ("positional",
         "Positional arguments: these are the arguments that are entered "


### PR DESCRIPTION
`--output` is without change, the other have their formatting customized for each option.
I know this is not a good solution (should be at least for the whole group, probably the whole cxxopts) but I did not have time to prepare more complex solution
```
  -o, --output [=BIN(=b.def)]   Output file (default: a.out)
      --formatted_option [arg_help]=abcd
                                Option with implicit value and custom 
                                format
      --formatted_option2 [arg_help=abcd]
                                Another option with implicit value 
                                and custom format
      --formatted_option3 [arg_help = abcd]
                                One more option with implicit value 
                                and custom format
      --no_implicit arg_help    Same as formatted_option but no 
                                implicit value
```